### PR TITLE
Invoke Backbone.Model.prototype.destroy with proper arguments

### DIFF
--- a/backbone.computed.js
+++ b/backbone.computed.js
@@ -210,8 +210,8 @@
         return _.extend(_.clone(this._previousAttributes) || {}, _.clone(this._previousComputedAttributes));
     };
 
-    BackboneComputedAttributeMixin.destroy = function() {
-        Backbone.Model.prototype.destroy.apply(this, arguments);
+    BackboneComputedAttributeMixin.destroy = function(model, collection, options) {
+        Backbone.Model.prototype.destroy.call(this, options);
         this.removeComputedAttributes();
     };
 


### PR DESCRIPTION
Backbone.Model.prototype.destroy was invoked with `model`, `collection`, and `options`, but it only accepts `options`